### PR TITLE
doc: Fix typos

### DIFF
--- a/doc/examples/create_dual_mesh.py
+++ b/doc/examples/create_dual_mesh.py
@@ -54,7 +54,7 @@ dual_Mesh_1 = smesh.CreateDualMesh( Mesh_1, 'dual_Mesh_1', True)
 assert(dual_Mesh_1.NbPolyhedrons() > 0)
 assert(dual_Mesh_1.NbTetras() == 0)
 
-# Creating Dual mesh withour projection on shape
+# Creating Dual mesh without projection on shape
 dual_Mesh_2 = smesh.CreateDualMesh( Mesh_1, 'dual_Mesh_2', False)
 
 assert(dual_Mesh_2.NbPolyhedrons() > 0)

--- a/doc/examples/creating_parallel_2D_mesh.py
+++ b/doc/examples/creating_parallel_2D_mesh.py
@@ -46,7 +46,7 @@ boxes = []
 #             boxes.append(box)
 
 #With 6 boxes works
-#But simplify for 2 boxes to also Test possibility of rewritting the
+#But simplify for 2 boxes to also Test possibility of rewriting the
 # input mesh from other parallel tests. In that case this test will break
 # because the input mesh will not match the exported/imported box geometry.
 for i in range(nbox):

--- a/doc/gui/input/additional_hypo.rst
+++ b/doc/gui/input/additional_hypo.rst
@@ -153,8 +153,8 @@ The Viscous Layer API receive the same parameters as the Viscous Layers Hypothes
 
 * The constructor ``ViscousLayerBuilder()``
 * The parameters definitions ``setBuilderParameters(...)``
-* The ``GetShrinkGeometry()`` method that returns the shrink version of the original geomtry.
-* The ``AddLayers( shrinkMesh )`` method that returns the complet version of the mesh (shrink+viscous layer)
+* The ``GetShrinkGeometry()`` method that returns the shrink version of the original geometry.
+* The ``AddLayers( shrinkMesh )`` method that returns the complete version of the mesh (shrink+viscous layer)
 
 **See also** a sample TUI script of a :ref:`tui_viscous_layers_api`.
 

--- a/doc/gui/input/constructing_submeshes.rst
+++ b/doc/gui/input/constructing_submeshes.rst
@@ -24,7 +24,7 @@ certain sub-shape, thus to get a locally coarser or finer mesh, to get
 elements of different types in the same mesh, etc.
 
 A sub-mesh can be meshed individually. To achieve this, select a
-sub-mesh and either invoke **Compute Sub-mesh** vai the contextual
+sub-mesh and either invoke **Compute Sub-mesh** via the contextual
 menu in the Object Browser or invoke **Mesh > Compute** menu.
 
 .. _submesh_shape_section: 

--- a/doc/gui/input/importing_exporting_meshes.rst
+++ b/doc/gui/input/importing_exporting_meshes.rst
@@ -28,7 +28,7 @@ It is possible to use additional file formats using **meshio** library.
 However, there are some restrictions because of way it uses in Salome. The main points here are:
 
 * We use intermediate MED file to communicate between Salome and **meshio**.
-* Convertion to the target format performs **meshio convert** command, using given **MED** file.
+* Conversion to the target format performs **meshio convert** command, using given **MED** file.
 * Current **meshio** version doesn't work well with all tested file formats. 
 
 Anyway, you can try to import/export meshes with **meshio** using following formats:

--- a/doc/gui/input/mesh_infos.rst
+++ b/doc/gui/input/mesh_infos.rst
@@ -91,7 +91,7 @@ The **Additional Info** tab page of the dialog box provides an additional inform
 For a mesh object, the following information is shown:
 
 * Name
-* Type: based on geomerty, imported, standalone
+* Type: based on geometry, imported, standalone
 * Shape (if mesh is based on geometry)
 * File (if mesh is imported from the file)
 * Groups

--- a/doc/gui/input/offset_elements.rst
+++ b/doc/gui/input/offset_elements.rst
@@ -41,7 +41,7 @@ Offset 2D elements in mesh, submesh, group or elements from filter.
 	.. image:: ../images/offset_filter_for_faces_gui.png
 		:align: center
 	
-	* Define the desired criterias and then click the **Apply and Close** button to confirm the selection of elements.
+	* Define the desired criteria and then click the **Apply and Close** button to confirm the selection of elements.
 	* Set **Offset** value and mesh creation **options** as done for the first case.
 
 #. Click the **Apply** or **Apply and Close** button to confirm the operation.

--- a/doc/gui/input/reload_mesh_from_file.rst
+++ b/doc/gui/input/reload_mesh_from_file.rst
@@ -12,7 +12,7 @@ This operation allows reload original imported mesh, which was modified by diffe
 #. Select a mesh(es) (and display it in the 3D Viewer if you are going to pick elements by mouse).
 #. From popup menu click on the *Reload from file* item
 
-Each selected mesh will be updated to orignal state with saving display properties
+Each selected mesh will be updated to original state with saving display properties
 
 .. image:: ../images/reload_mesh_orig_mesh.png 
 	:align: center


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.pdf,*.ts,*.po" -L afile,alledges,aline,anid,anumber,anormal,apoints,ascript,asender,attributs,bloc,blocs,bord,coo,cylindre,discret,domin,groupe,groupes,inout,ist,methode,myu,normale,objet,presse,siz,theres,thex,unexpect,vertexes`